### PR TITLE
woff2 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ module.exports = {
 
       // Needed for the css-loader when [bootstrap-webpack](https://github.com/bline/bootstrap-webpack)
       // loads bootstrap's css.
+      { test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,   loader: "url?limit=10000&mimetype=application/font-woff2" },
       { test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,   loader: "url?limit=10000&mimetype=application/font-woff" },
       { test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,    loader: "url?limit=10000&mimetype=application/octet-stream" },
       { test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,    loader: "file" },


### PR DESCRIPTION
Prevent

ERROR in ./~/bootstrap/fonts/glyphicons-halflings-regular.woff2
Module parse failed: /home/neo/progects/protos/client/node_modules/bootstrap/fonts/glyphicons-halflings-regular.woff2 Line 1: Unexpected token ILLEGAL
You may need an appropriate loader to handle this file type.
(Source code omitted for this binary file)
 @ ./~/bootstrap-webpack/~/css-loader!./~/bootstrap-webpack/~/less-loader!./~/bootstrap-webpack/bootstrap-styles.loader.js!./bootstrap.config.js 2:56882-56943