### PR TITLE
Changes to README.ME

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module.exports = {
     loaders: [
       // the url-loader uses DataUrls.
       // the file-loader emits files.
-      { test: /\.woff$/,   loader: "url-loader?limit=10000&mimetype=application/font-woff" },
+      { test: /\.(woff|woff2)$/,  loader: "url-loader?limit=10000&mimetype=application/font-woff" },
       { test: /\.ttf$/,    loader: "file-loader" },
       { test: /\.eot$/,    loader: "file-loader" },
       { test: /\.svg$/,    loader: "file-loader" }
@@ -57,6 +57,33 @@ module.exports = {
   ]
 };
 ```
+
+### Using with other js loaders.
+
+If you are using other loaders for all js files`(test: /\.js$/)`, this might interfere with bootstrap-webpack.
+You can override the configuration loader order in the module request to suit special cases.
+
+* adding ! to a request will disable configured preLoaders
+``` javascript
+require("!bootstrap-webpack!./bootstrap.config.js")
+```
+* adding !! to a request will disable all loaders specified in the configuration
+``` javascript
+require("!!bootstrap-webpack!./bootstrap.config.js")
+```
+* adding -! to a request will disable configured preLoaders and loaders but not the postLoaders
+``` javascript
+require("-!bootstrap-webpack!./bootstrap.config.js")
+```
+
+Check details in [`webpack loader order`](https://webpack.github.io/docs/loaders.html)
+
+You can also change your configuration, so that other loaders are not applied to bootstrap.
+
+1. Use `exclude` option of the module.loaders section of the config.
+2. Adjust the regex in `test` option of the module loaders to prevent matching all the js files to which the loaders are applied.
+
+See the explanation of different module options under [`module.loaders`](http://webpack.github.io/docs/configuration.html)
 
 #### `bootstrap.config.js`
 

--- a/README.md
+++ b/README.md
@@ -123,15 +123,33 @@ Example:
 
 ### extract-text-webpack-plugin
 
-Configure post style loaders in `bootstrap.config.js`.
+Configure style loader in `bootstrap.config.js`.
 
 Example:
 
 ``` javascript
 module.exports = {
-  postStyleLoaders: [
-    require.resolve('extract-text-webpack-plugin/loader.js') + '?{"omit":1,"extract":true,"remove":true}'
-  ],
+  styleLoader: require('extract-text-webpack-plugin').extract('style-loader', 'css-loader!less-loader'),
+  scripts: {
+    ...
+  },
+  styles: {
+    ...
+  }
+};
+```
+
+Install `extract-text-webpack-plugin` before using this configuration.
+
+### extract-text-webpack-plugin and postcss-loader
+
+Configure style loader in `bootstrap.config.js`.
+
+Example:
+
+``` javascript
+module.exports = {
+  styleLoader: require('extract-text-webpack-plugin').extract('style-loader', 'css-loader!postcss-loader!less-loader'),
   scripts: {
     ...
   },

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 bootstrap-webpack
 =================
 
-bootstrap package for webpack
+bootstrap package for webpack.
+
+This is the `less` version. If you are looking for the `sass` version, refer to [bootstrap-sass-loader](https://github.com/justin808/bootstrap-sass-loader).
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -91,3 +91,25 @@ Example:
 @btn-default-color:              #444;
 @btn-default-bg:                 #eee;
 ```
+
+### extract-text-webpack-plugin
+
+Configure post style loaders in `bootstrap.config.js`.
+
+Example:
+
+``` javascript
+module.exports = {
+  postStyleLoaders: [
+    require.resolve('extract-text-webpack-plugin/loader.js') + '?{"omit":1,"extract":true,"remove":true}'
+  ],
+  scripts: {
+    ...
+  },
+  styles: {
+    ...
+  }
+};
+```
+
+Install `extract-text-webpack-plugin` before using this configuration.

--- a/README.md
+++ b/README.md
@@ -26,13 +26,7 @@ module.exports = {
 };
 ```
 
-Bootstrap javascript components depends on jQuery. The simplest way of adding jQuery to your webpack app is by exposing `$` and `jQuery` to global namespace.
-
-``` javascript
-require('expose?$!expose?jQuery!jquery');
-```
-
-Add it before requiring `bootstrap-webpack`. This uses `expose-loader` of webpack. Install [expose-loader](https://github.com/webpack/expose-loader) by `npm install expose-loader --save-dev`.
+Bootstrap javascript components depends on jQuery. This uses `imports-loader` of webpack. Install [imports-loader](https://github.com/webpack/imports-loader) by `npm install imports-loader --save-dev`.
 
 ### Complete Bootstrap
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ module.exports = {
     loaders: [
       // the url-loader uses DataUrls.
       // the file-loader emits files.
-      { test: /\.(woff|woff2)$/,  loader: "url-loader?limit=10000&mimetype=application/font-woff" },
-      { test: /\.ttf$/,    loader: "file-loader" },
-      { test: /\.eot$/,    loader: "file-loader" },
-      { test: /\.svg$/,    loader: "file-loader" }
+      {test: /\.(woff|woff2)(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&mimetype=application/font-woff'},
+      {test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&mimetype=application/octet-stream'},
+      {test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'file'},
+      {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url?limit=10000&mimetype=image/svg+xml'}
     ]
   }
 };
 ```
+
+Bootstrap javascript components depends on jQuery. The simplest way of adding jQuery to your webpack app is by exposing `$` and `jQuery` to global namespace.
+
+``` javascript
+require('expose?$!expose?jQuery!jquery');
+```
+
+Add it before requiring `bootstrap-webpack`. This uses `expose-loader` of webpack. Install [expose-loader](https://github.com/webpack/expose-loader) by `npm install expose-loader --save-dev`.
 
 ### Complete Bootstrap
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ module.exports = {
     loaders: [
       // the url-loader uses DataUrls.
       // the file-loader emits files.
-      { test: /\.woff$/,   loader: "url-loader?limit=10000&minetype=application/font-woff" },
+      { test: /\.woff$/,   loader: "url-loader?limit=10000&mimetype=application/font-woff" },
       { test: /\.ttf$/,    loader: "file-loader" },
       { test: /\.eot$/,    loader: "file-loader" },
       { test: /\.svg$/,    loader: "file-loader" }

--- a/bootstrap-scripts.loader.js
+++ b/bootstrap-scripts.loader.js
@@ -21,6 +21,6 @@ module.exports.pitch = function (configPath) {
   return scripts.filter(function (script) {
     return config.scripts[script];
   }).map(function (script) {
-    return "require(" + JSON.stringify("bootstrap/js/" + script) + ");";
+    return "require(" + JSON.stringify("imports?jQuery=jquery!bootstrap/js/" + script) + ");";
   }).join("\n");
 }

--- a/bootstrap.config.js
+++ b/bootstrap.config.js
@@ -1,4 +1,8 @@
 module.exports = {
+
+  // Default for the style loading
+  styleLoader: 'style-loader!css-loader!less-loader',
+    
   scripts: {
     'transition': true,
     'alert': true,

--- a/index.loader.js
+++ b/index.loader.js
@@ -1,8 +1,13 @@
 module.exports = function () {};
 module.exports.pitch = function (remainingRequest) {
   this.cacheable(true);
+  var config = require(this.resourcePath);
+  var postStyleLoaders = '';
+  if((typeof config.postStyleLoaders !== 'undefined') && (config.postStyleLoaders.length > 0)){
+    postStyleLoaders = config.postStyleLoaders.join('!') + '!';
+  }
   return [
-    'require(' + JSON.stringify("-!" + require.resolve("style-loader") + '!' + require.resolve("css-loader") +
+    'require(' + JSON.stringify("-!" + postStyleLoaders + require.resolve("style-loader") + '!' + require.resolve("css-loader") +
       '!' + require.resolve("less-loader") + '!' + require.resolve("./bootstrap-styles.loader.js") + '!' + remainingRequest) + ');',
     'require(' + JSON.stringify("-!" + require.resolve("./bootstrap-scripts.loader.js") + "!" + remainingRequest) + ');'
   ].join("\n");

--- a/index.loader.js
+++ b/index.loader.js
@@ -1,14 +1,29 @@
-module.exports = function () {};
+module.exports = function() {
+};
+
 module.exports.pitch = function (remainingRequest) {
+
+  // Webpack 1.7.3 uses this.resourcePath. Leaving in remaining request for possibly older versions
+  // of Webpack
+  var configFilePath = this.resourcePath || remainingRequest;
   this.cacheable(true);
-  var config = require(this.resourcePath);
-  var postStyleLoaders = '';
-  if((typeof config.postStyleLoaders !== 'undefined') && (config.postStyleLoaders.length > 0)){
-    postStyleLoaders = config.postStyleLoaders.join('!') + '!';
+
+  if (!configFilePath || configFilePath.trim() === '') {
+    var msg = 'You specified the bootstrap-webpack with no configuration file. Please specify' +
+      ' the configuration file, like: \'bootstrap-webpack!./bootstrap.config.js\' or use' +
+      ' require(\'bootstrap-webpack\').';
+    console.error('ERROR: ' + msg);
+    throw new Error(msg);
   }
-  return [
-    'require(' + JSON.stringify("-!" + postStyleLoaders + require.resolve("style-loader") + '!' + require.resolve("css-loader") +
-      '!' + require.resolve("less-loader") + '!' + require.resolve("./bootstrap-styles.loader.js") + '!' + remainingRequest) + ');',
-    'require(' + JSON.stringify("-!" + require.resolve("./bootstrap-scripts.loader.js") + "!" + remainingRequest) + ');'
-  ].join("\n");
+  
+  var config = require(configFilePath);
+  var styleLoader = config.styleLoader || 'style-loader!css-loader!less-loader';
+
+  var styleLoaderCommand = 'require(' + JSON.stringify('-!' + styleLoader + '!' +
+      require.resolve('./bootstrap-styles.loader.js') + '!' + configFilePath) + ');';
+  var jsLoaderCommand = 'require(' + JSON.stringify('-!' +
+      require.resolve('./bootstrap-scripts.loader.js') + '!' + configFilePath) + ');';
+  var result = [styleLoaderCommand, jsLoaderCommand].join('\n');
+  return result;
+
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "url": "https://github.com/bline/bootstrap-webpack.git"
   },
   "peerDependencies": {
-    "bootstrap": "~3.0.2"
+    "bootstrap": ">=3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-webpack",
   "description": "bootstrap3 package for webpack",
   "main": "index.js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "loader": "index.loader.js",
   "keywords": [
     "bootstrap",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,19 @@
   "bugs": {
     "url": "https://github.com/gowravshekar/bootstrap-webpack/issues"
   },
-  "dependencies": {
-    "css-loader": "~0.6.3",
-    "less-loader": "~0.6.2",
-    "style-loader": "~0.6.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/gowravshekar/bootstrap-webpack.git"
   },
   "peerDependencies": {
-    "bootstrap": ">=3.0.2"
+    "bootstrap": ">=3.0.2",
+    "css-loader": ">=0.6.3",
+    "less-loader": ">=0.6.2",
+    "style-loader": ">=0.6.0",
+    "url-loader": ">=0.5.5",
+    "file-loader": ">=0.8.1",
+    "imports-loader": ">=0.6.3",
+    "exports-loader": ">=0.6.2",
+    "extract-text-webpack-plugin": ">=0.3.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-webpack",
   "description": "bootstrap3 package for webpack",
   "main": "index.js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "loader": "index.loader.js",
   "keywords": [
     "bootstrap",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "url": "https://github.com/bline/bootstrap-webpack.git"
   },
   "peerDependencies": {
-    "bootstrap": "3.0.2"
+    "bootstrap": "~3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-webpack",
   "description": "bootstrap3 package for webpack",
   "main": "index.js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "loader": "index.loader.js",
   "keywords": [
     "bootstrap",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "css-loader": "~0.6.3",
-    "less-loader": "~0.6.1",
+    "less-loader": "~0.6.2",
     "style-loader": "~0.6.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bootstrap-webpack",
   "description": "bootstrap3 package for webpack",
   "main": "index.js",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "loader": "index.loader.js",
   "keywords": [
     "bootstrap",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "name": "Scott Beck (@bline)"
   },
   "bugs": {
-    "url": "https://github.com/bline/bootstrap-webpack/issues"
+    "url": "https://github.com/gowravshekar/bootstrap-webpack/issues"
   },
   "dependencies": {
     "css-loader": "~0.6.3",
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/bline/bootstrap-webpack.git"
+    "url": "https://github.com/gowravshekar/bootstrap-webpack.git"
   },
   "peerDependencies": {
     "bootstrap": ">=3.0.2"


### PR DESCRIPTION
Change instructions to rather do:
`new webpack.ProvidePlugin({
    $: "jquery",
    jQuery: "jquery",
    "window.jQuery": "jquery"` , 
to make it more clear. This exposes every module as a variable instead of exposing it all to the global namespace. This is for local jquery/bootstrap I guess, but I don't know if bootstrap **requires** it to all be global context.
